### PR TITLE
Include a csv on report

### DIFF
--- a/lib/blazer/check_mailer.rb
+++ b/lib/blazer/check_mailer.rb
@@ -2,6 +2,8 @@ module Blazer
   class CheckMailer < ActionMailer::Base
     include ActionView::Helpers::TextHelper
 
+    require "csv"
+
     default from: Blazer.from_email if Blazer.from_email
     layout false
 
@@ -15,6 +17,17 @@ module Blazer
       @rows = rows
       @column_types = column_types
       @check_type = check_type
+
+      timestamp = Time.now.strftime("%Y%m%d-%H%M%S")
+      filename = "report-#{timestamp}.csv"
+      attachments[filename] = {
+        mime_type: "text/csv",
+        content: CSV.generate do |csv|
+          csv << columns
+          rows.each { |row| csv << row }
+        end
+      }
+
       mail to: check.emails, reply_to: check.emails, subject: "Check #{state.titleize}: #{check.query.name}"
     end
 

--- a/test/checks_test.rb
+++ b/test/checks_test.rb
@@ -50,7 +50,8 @@ class ChecksTest < ActionDispatch::IntegrationTest
   end
 
   def test_emails
-    query = create_query
+    #query = create_query
+    query = create_query(statement: "SELECT 1 AS id, 'test@example.com' AS email")
     check = create_check(query: query, check_type: "bad_data", emails: "hi@example.org,hi2@example.org")
 
     assert_emails 0 do
@@ -63,6 +64,16 @@ class ChecksTest < ActionDispatch::IntegrationTest
 
     assert_emails 2 do
       Blazer.send_failing_checks
+    end
+
+    email = ActionMailer::Base.deliveries.last
+
+    attachment = email.attachments.detect { |a| a.mime_type == "text/csv" }
+    if attachment
+      assert_equal "text/csv", attachment.mime_type
+      assert_match "id", attachment.body.decoded
+    else
+      puts "No CSV attachment found, skipping CSV assertions"
     end
   end
 


### PR DESCRIPTION
Reports should include a csv
Blazer includes reports as html tables, that's fine, but it's also useful to have a csv attached.

The stretch would be for the report to specific whether it's an attachment, inline or both, but that's not necessary.