### PR TITLE
add Option to deliver every report

### DIFF
--- a/app/models/blazer/check.rb
+++ b/app/models/blazer/check.rb
@@ -67,7 +67,7 @@ module Blazer
       end
 
       # do not notify on creation, except when not passing
-      if (state_was != "new" || state != "passing") && state != state_was
+      if check_type == "always" || ((state_was != "new" || state != "passing") && state != state_was)
         Blazer::CheckMailer.state_change(self, state, state_was, result.rows.size, message, result.columns, result.rows.first(10).as_json, result.column_types, check_type).deliver_now if emails.present?
         Blazer::SlackNotifier.state_change(self, state, state_was, result.rows.size, message, check_type)
       end

--- a/app/views/blazer/checks/_form.html.erb
+++ b/app/views/blazer/checks/_form.html.erb
@@ -24,7 +24,7 @@
     <div class="form-group">
       <%= f.label :check_type, "Alert if" %>
       <div class="hide">
-        <% check_options = [["Any results (bad data)", "bad_data"], ["No results (missing data)", "missing_data"]] %>
+        <% check_options = [["Any results (bad data)", "bad_data"], ["No results (missing data)", "missing_data"], ["Always", "always"]] %>
         <% check_options << ["Anomaly (most recent data point)", "anomaly"] if Blazer.anomaly_checks %>
         <%= f.select :check_type, check_options %>
       </div>

--- a/test/checks_test.rb
+++ b/test/checks_test.rb
@@ -66,6 +66,16 @@ class ChecksTest < ActionDispatch::IntegrationTest
     end
   end
 
+  def test_emails_always
+    query = create_query
+    check = create_check(query: query, check_type: "always", emails: "hi@example.org,hi2@example.org")
+
+    assert_emails 2 do
+      Blazer.run_checks(schedule: "5 minutes")
+      Blazer.run_checks(schedule: "5 minutes")
+    end
+  end
+
   def test_slack
     query = create_query
     check = create_check(query: query, check_type: "bad_data", slack_channels: "#general,#random")


### PR DESCRIPTION
Option to deliver every report
Blazer checks will run when a query either does return data and then again when it doesn't or when it does return data and then again when it doesn't.

That's less useful for the cases where we just want someone to get a daily report sent to them. We should be able to introduce an always case.